### PR TITLE
msm: kgsl: Put a keep alive vote before updating CP_RB_WPTR

### DIFF
--- a/drivers/gpu/msm/adreno_a6xx_preempt.c
+++ b/drivers/gpu/msm/adreno_a6xx_preempt.c
@@ -50,6 +50,29 @@ static void _update_wptr(struct adreno_device *adreno_dev, bool reset_timer)
 		if (rb->skip_inline_wptr) {
 			write = true;
 			val = rb->wptr;
+			/*
+			 * There could be a situation where GPU comes out of
+			 * ifpc after a fenced write transaction but before
+			 * reading AHB_FENCE_STATUS from KMD, it goes back to
+			 * ifpc due to inactivity (kernel scheduler plays a
+			 * role here). Thus, the GPU could technically be
+			 * re-collapsed between subsequent register writes
+			 * leading to a prolonged preemption sequence. The
+			 * keepalive bit prevents any further power collapse
+			 * while it is set.
+			 */
+			if (gmu_core_isenabled(device))
+				gmu_core_regrmw(device, A6XX_GMU_AO_SPARE_CNTL,
+					0x0, 0x2);
+
+			ret = adreno_gmu_fenced_write(adreno_dev,
+				ADRENO_REG_CP_RB_WPTR, rb->wptr,
+				FENCE_STATUS_WRITEDROPPED0_MASK);
+
+			/* Clear the keep alive */
+			if (gmu_core_isenabled(device))
+				gmu_core_regrmw(device, A6XX_GMU_AO_SPARE_CNTL,
+					0x2, 0x0);
 
 			reset_timer = true;
 			rb->skip_inline_wptr = false;


### PR DESCRIPTION
There could be a situation where GPU comes out of ifpc after a
fenced write transaction but before reading AHB_FENCE_STATUS from
KMD, it goes back to ifpc due to inactivity.
Put a keep alive vote before doing fenced write for CP_RB_WPTR to
avoid such unlikely scenario.

Change-Id: Ibe0391b39cedf64e2dfa78ab0bbcda0fc8746c88
Signed-off-by: Pankaj Gupta <gpankaj@codeaurora.org>