### PR TITLE
arm64: dts: sm8150: Power off DSI PHY during idle PC

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm8150-sde.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-sde.dtsi
@@ -532,6 +532,7 @@
 						00 00 0a 0a
 						00 00 8a 8a];
 		qcom,platform-regulator-settings = [1d 1d 1d 1d 1d];
+		qcom,panel-allow-phy-poweroff;
 		qcom,phy-supply-entries {
 			#address-cells = <1>;
 			#size-cells = <0>;


### PR DESCRIPTION
On command mode panels, we can power off the DSI PHY entirely during
idle PC to save more power than ULPS.

Signed-off-by: Danny Lin <danny@kdrag0n.dev>