### PR TITLE
mm: vmstat: use power efficient workingqueues

### DIFF
--- a/mm/vmstat.c
+++ b/mm/vmstat.c
@@ -1873,7 +1873,7 @@ static void vmstat_shepherd(struct work_struct *w)
 	}
 	put_online_cpus();
 
-	schedule_delayed_work(&shepherd,
+	queue_delayed_work(system_power_efficient_wq, &shepherd,
 		round_jiffies_relative(sysctl_stat_interval));
 }
 
@@ -1885,7 +1885,7 @@ static void __init start_shepherd_timer(void)
 		INIT_DEFERRABLE_WORK(per_cpu_ptr(&vmstat_work, cpu),
 			vmstat_update);
 
-	schedule_delayed_work(&shepherd,
+	queue_delayed_work(system_power_efficient_wq, &shepherd,
 		round_jiffies_relative(sysctl_stat_interval));
 }
 


### PR DESCRIPTION
(cherry picked from commit 52e60a930f0480f2082bc65836c7edb4861de7aa)
(cherry picked from commit bb05861a4f3bb99b76e7e43ba17f3659fcb12443)
(cherry picked from commit d92be4aa5222a52104bed81fe60c5c10a091b4c1)
(cherry picked from commit cc59747fd00d37a9cbcfc3d5175de1a9062dd758)
(cherry picked from commit 101acdd830d9b9cd02104b7721886ee3d16a3930)
(cherry picked from commit faf5434d8d14ae88886aa7b21308c68ff2bce208)
(cherry picked from commit edb793442e06e5499761c40335b109118d13d676)
(cherry picked from commit 36d9884dd06be11d312174806f5635fad205d96c)
(cherry picked from commit e70e90b8bd8f7eba350557a51048f6431bd990b6)
(cherry picked from commit 00435c742ef51bd564c67783c6293b5595cad78a)
(cherry picked from commit bbb0e3f4da83044c498ca8d420acc42f61e73305)
(cherry picked from commit 2dfa7552c5c95362b901a7ec3f670352fcb4db31)