### PR TITLE
gpu: drm: use power efficient workingqueues

### DIFF
--- a/drivers/gpu/drm/drm_probe_helper.c
+++ b/drivers/gpu/drm/drm_probe_helper.c
@@ -257,7 +257,8 @@ void drm_kms_helper_poll_enable(struct drm_device *dev)
 	}
 
 	if (poll)
-		schedule_delayed_work(&dev->mode_config.output_poll_work, delay);
+		queue_delayed_work(system_power_efficient_wq, 
+							&dev->mode_config.output_poll_work, delay);
 }
 EXPORT_SYMBOL(drm_kms_helper_poll_enable);
 
@@ -465,8 +466,8 @@ retry:
 		 */
 		dev->mode_config.delayed_event = true;
 		if (dev->mode_config.poll_enabled)
-			schedule_delayed_work(&dev->mode_config.output_poll_work,
-					      0);
+			queue_delayed_work(system_power_efficient_wq, 
+								&dev->mode_config.output_poll_work, 0);
 	}
 
 	/* Re-enable polling in case the global poll config changed. */
@@ -671,7 +672,8 @@ out:
 		drm_kms_helper_hotplug_event(dev);
 
 	if (repoll)
-		schedule_delayed_work(delayed_work, DRM_OUTPUT_POLL_PERIOD);
+		queue_delayed_work(system_power_efficient_wq, delayed_work, 
+							DRM_OUTPUT_POLL_PERIOD);
 }
 
 /**

--- a/drivers/gpu/drm/msm/sde/sde_connector.c
+++ b/drivers/gpu/drm/msm/sde/sde_connector.c
@@ -398,7 +398,7 @@ void sde_connector_schedule_status_work(struct drm_connector *connector,
 				c_conn->esd_status_interval :
 					STATUS_CHECK_INTERVAL_MS;
 			/* Schedule ESD status check */
-			schedule_delayed_work(&c_conn->status_work,
+			queue_delayed_work(system_power_efficient_wq, &c_conn->status_work,
 				msecs_to_jiffies(interval));
 			c_conn->esd_status_check = true;
 			dsi_display_change_err_flag_irq_status(dsi_display, true);
@@ -2137,7 +2137,7 @@ static void sde_connector_check_status_work(struct work_struct *work)
 		/* If debugfs property is not set then take default value */
 		interval = conn->esd_status_interval ?
 			conn->esd_status_interval : STATUS_CHECK_INTERVAL_MS;
-		schedule_delayed_work(&conn->status_work,
+		queue_delayed_work(system_power_efficient_wq, &conn->status_work,
 			msecs_to_jiffies(interval));
 		return;
 	}


### PR DESCRIPTION
(cherry picked from commit f83b34ad7998f3d26259d8ae39ad23a9a8ce6974)
(cherry picked from commit 21421bee643a6211213a62d23cdb4a089bc7edbd)
(cherry picked from commit 70c107ebae07c53d825ebec8de7d8c7e25196a7d)
(cherry picked from commit 95cadd992dc093fc9b7a9afc72c3531d8b2ca974)
(cherry picked from commit 8a83456c3d3667dedcf34286b664cb2238e5f372)
(cherry picked from commit d93fb31610787735aa3d470c21e0d4e3247010ce)
(cherry picked from commit 5b927ff3f387c3747ec163c6e7d198f76bdd4006)
(cherry picked from commit 85236cefba73d426ce9b82188156462d0aac7d83)
(cherry picked from commit 8fb912674cf9986f5da8698ccd0cee3874f9cfca)