### PR TITLE
msm: msm_bus: Kill transaction logging functionality

### DIFF
--- a/drivers/soc/qcom/msm_bus/msm_bus_arb_rpmh.c
+++ b/drivers/soc/qcom/msm_bus/msm_bus_arb_rpmh.c
@@ -1339,8 +1339,7 @@ exit_register_client:
 	return handle;
 }
 
-static int update_client_paths(struct msm_bus_client *client, bool log_trns,
-							unsigned int idx)
+static int update_client_paths(struct msm_bus_client *client, unsigned int idx)
 {
 	int lnode, src, dest, cur_idx;
 	uint64_t req_clk, req_bw, curr_clk, curr_bw, slp_clk, slp_bw;
@@ -1410,17 +1409,13 @@ static int update_client_paths(struct msm_bus_client *client, bool log_trns,
 			if (dev)
 				msm_bus_commit_single(dev);
 		}
-
-		if (log_trns)
-			getpath_debug(src, lnode, pdata->active_only);
 	}
 	commit_data();
 exit_update_client_paths:
 	return ret;
 }
 
-static int update_client_alc(struct msm_bus_client *client, bool log_trns,
-							unsigned int idx)
+static int update_client_alc(struct msm_bus_client *client, unsigned int idx)
 {
 	int lnode, cur_idx;
 	uint64_t req_idle_time, req_fal, dual_idle_time, dual_fal,
@@ -1599,7 +1594,7 @@ static int update_context(uint32_t cl, bool active_only,
 	pdata->active_only = active_only;
 
 	msm_bus_dbg_client_data(client->pdata, ctx_idx, cl);
-	ret = update_client_paths(client, false, ctx_idx);
+	ret = update_client_paths(client, ctx_idx);
 	if (ret) {
 		pr_err("%s: Err updating path\n", __func__);
 		goto exit_update_context;
@@ -1617,8 +1612,6 @@ static int update_request_adhoc(uint32_t cl, unsigned int index)
 	int ret = 0;
 	struct msm_bus_scale_pdata *pdata;
 	struct msm_bus_client *client;
-	const char *test_cl = "Null";
-	bool log_transaction = false;
 
 	rt_mutex_lock(&msm_bus_adhoc_lock);
 
@@ -1656,17 +1649,14 @@ static int update_request_adhoc(uint32_t cl, unsigned int index)
 		goto exit_update_request;
 	}
 
-	if (!strcmp(test_cl, pdata->name))
-		log_transaction = true;
-
 	MSM_BUS_DBG("%s: cl: %u index: %d curr: %d num_paths: %d\n", __func__,
 		cl, index, client->curr, client->pdata->usecase->num_paths);
 
 	if (pdata->alc)
-		ret = update_client_alc(client, log_transaction, index);
+		ret = update_client_alc(client, index);
 	else {
 		msm_bus_dbg_client_data(client->pdata, index, cl);
-		ret = update_client_paths(client, log_transaction, index);
+		ret = update_client_paths(client, index);
 	}
 	if (ret) {
 		pr_err("%s: Err updating path\n", __func__);


### PR DESCRIPTION
The transaction logging (and especially strcmp call) is unnecessary for
us and adds measurably significant overhead. Kill it entirely.

Signed-off-by: Danny Lin <danny@kdrag0n.dev>
(cherry picked from commit d7526da3fec1f7c72ef06dedd3863fb8da0e49e6)
(cherry picked from commit f9859f835c4a0a581f7327ad842fb7e70c480910)
(cherry picked from commit 875f39cd50beb3ac4d4b6f02e3c9bc2a1a5b7bf9)
(cherry picked from commit 5f3e8ec74ddebf2a85367d922afe360840d52e94)
(cherry picked from commit 01bf660efe829459ff33aef1192372022d309ba4)
(cherry picked from commit 1611a4b56a4e296c66e4ee24f4bf671bc6eb8cde)
(cherry picked from commit 126d83b33a8e974e3fa9c33a8cb99bb28119f852)
(cherry picked from commit a483d48d89be827bec3e840910c8011f82c96090)
(cherry picked from commit 12c88e922236a41fc4ba99000557a93df6b02198)
(cherry picked from commit 7a1f1f79891d878c673bf039dea69b482b805d64)