### PR TITLE
msm: kgsl: Don't allocate memory dynamically for temp command buffers

### DIFF
--- a/drivers/gpu/msm/adreno_iommu.c
+++ b/drivers/gpu/msm/adreno_iommu.c
@@ -802,21 +802,15 @@ static int _set_pagetable_cpu(struct adreno_ringbuffer *rb,
 static int _set_pagetable_gpu(struct adreno_ringbuffer *rb,
 			struct kgsl_pagetable *new_pt)
 {
+	static unsigned int link[PAGE_SIZE / sizeof(unsigned int)]
+		____cacheline_aligned_in_smp;
 	struct adreno_device *adreno_dev = ADRENO_RB_DEVICE(rb);
-	unsigned int *link = NULL, *cmds;
+	unsigned int *cmds = link;
 	int result;
 
-	link = kmalloc(PAGE_SIZE, GFP_KERNEL);
-	if (link == NULL)
-		return -ENOMEM;
-
-	cmds = link;
-
 	/* If we are in a fault the MMU will be reset soon */
-	if (test_bit(ADRENO_DEVICE_FAULT, &adreno_dev->priv)) {
-		kfree(link);
+	if (test_bit(ADRENO_DEVICE_FAULT, &adreno_dev->priv))
 		return 0;
-	}
 
 	cmds += adreno_iommu_set_pt_generate_cmds(rb, cmds, new_pt);
 
@@ -838,7 +832,6 @@ static int _set_pagetable_gpu(struct adreno_ringbuffer *rb,
 			KGSL_CMD_FLAGS_PMODE, link,
 			(unsigned int)(cmds - link));
 
-	kfree(link);
 	return result;
 }
 

--- a/drivers/gpu/msm/adreno_ringbuffer.c
+++ b/drivers/gpu/msm/adreno_ringbuffer.c
@@ -978,6 +978,7 @@ int adreno_ringbuffer_submitcmd(struct adreno_device *adreno_dev,
 	struct kgsl_memobj_node *ib;
 	unsigned int numibs = 0;
 	unsigned int *link;
+	unsigned int link_onstack[SZ_256] __aligned(8);
 	unsigned int *cmds;
 	struct kgsl_context *context;
 	struct adreno_context *drawctxt;
@@ -1112,10 +1113,15 @@ int adreno_ringbuffer_submitcmd(struct adreno_device *adreno_dev,
 	if (gpudev->ccu_invalidate)
 		dwords += 4;
 
-	link = kcalloc(dwords, sizeof(unsigned int), GFP_KERNEL);
-	if (!link) {
-		ret = -ENOMEM;
-		goto done;
+	if (likely(dwords <= ARRAY_SIZE(link_onstack))) {
+		memset(link_onstack, 0, dwords * sizeof(unsigned int));
+		link = link_onstack;
+	} else {
+		link = kcalloc(dwords, sizeof(unsigned int), GFP_KERNEL);
+		if (!link) {
+			ret = -ENOMEM;
+			goto done;
+		}
 	}
 
 	cmds = link;
@@ -1243,7 +1249,8 @@ done:
 	trace_kgsl_issueibcmds(device, context->id, numibs, drawobj->timestamp,
 			drawobj->flags, ret, drawctxt->type);
 
-	kfree(link);
+	if (unlikely(link != link_onstack))
+		kfree(link);
 	return ret;
 }
 


### PR DESCRIPTION
The temporary command buffer in _set_pagetable_gpu is only the size of a
single page, and _set_pagetable_gpu is never executed concurrently. It
is therefore easy to replace the dynamic command buffer allocation with
a static one to improve performance by avoiding the latency of dynamic
memory allocation.

Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
(cherry picked from commit 402dd274db83e84889c838bf999cca546141e3fd)
(cherry picked from commit 044713c9babd70c2c4d24d8ca7d7f8105b609214)
(cherry picked from commit 214798a77dfba7cc7fe3edd6e1e66eb28285f8cf)
(cherry picked from commit ed3591555b1361a15c18929cd76fdd826143e726)
(cherry picked from commit b65129bbf2ba827229daf0899e536737f0855d00)
(cherry picked from commit 98e81783e4d993a084b17a218355b9ba171f6352)
(cherry picked from commit ad6e22f0dad27b9ec31a9e66f3f940b17223b75c)
(cherry picked from commit 39921407ea7d02a7907e831ffd8d3456e15fbb0b)
(cherry picked from commit 63dd9af8758bfdfe35bb6adacd0873b60438adfc)
(cherry picked from commit 937c3e06a1ed8f4fcdc20160278ee204c7806c52)