### PR TITLE
drm/msm/sde: use kmem_cache pool for struct sde_fence

### DIFF
--- a/drivers/gpu/drm/msm/sde/sde_fence.c
+++ b/drivers/gpu/drm/msm/sde/sde_fence.c
@@ -263,6 +263,8 @@ struct sde_fence_context *sde_fence_init(const char *name, uint32_t drm_id)
 		return ERR_PTR(-ENOMEM);
 	}
 
+	kmem_fence_pool = KMEM_CACHE(sde_fence, SLAB_HWCACHE_ALIGN | SLAB_PANIC);
+
 	strlcpy(ctx->name, name, ARRAY_SIZE(ctx->name));
 	ctx->drm_id = drm_id;
 	kref_init(&ctx->kref);
@@ -283,6 +285,8 @@ void sde_fence_deinit(struct sde_fence_context *ctx)
 	}
 
 	kref_put(&ctx->kref, sde_fence_destroy);
+
+	kmem_cache_destroy(kmem_fence_pool);
 }
 
 void sde_fence_prepare(struct sde_fence_context *ctx)


### PR DESCRIPTION
These get allocated and freed millions of times on this kernel tree.

Use a dedicated kmem_cache pool and avoid costly dynamic memory allocations.

Signed-off-by: Park Ju Hyung <qkrwngud825@gmail.com>
(cherry picked from commit 27c1e0a95db45a3c3ec3a2c67b18b27b95c540af)
(cherry picked from commit 97559ef0ed889072b9326a56ba4339cea146ce42)
(cherry picked from commit 02b2cefc09b0ae83548e592c6fc5bbe36a943a84)
(cherry picked from commit 81576641c23389314338b3f3bca6f9b980b1a972)
(cherry picked from commit 69f6c6b2420228cd1a90d94b1327250b9c3fcde1)
(cherry picked from commit cac07a276b9e98d35d9f43a4af48f19c132586f5)
(cherry picked from commit 59e35eead6cca3453dce03f8d190d663f169fb40)
(cherry picked from commit dcadad1c22cf0f20249f1db2d87a764a81e4e981)
(cherry picked from commit 0ba72455d6490c3c5a6c101eb3e7cdaa0be60c07)
(cherry picked from commit 2b98a746becc058a2a5e61cdb1bf05aecd0e4b9c)