### PR TITLE
Make msm_serial_hs RT to improve Bluetooth performance

### DIFF
--- a/drivers/tty/serial/msm_serial_hs.c
+++ b/drivers/tty/serial/msm_serial_hs.c
@@ -61,6 +61,7 @@
 #include <linux/ipc_logging.h>
 #include <asm/irq.h>
 #include <linux/kthread.h>
+#include <uapi/linux/sched.h>
 
 #include <linux/msm-sps.h>
 #include <linux/platform_data/msm_serial_hs.h>
@@ -3305,6 +3306,7 @@ static void  msm_serial_hs_rt_init(struct uart_port *uport)
 	msm_uport->pm_state = MSM_HS_PM_SUSPENDED;
 	mutex_unlock(&msm_uport->mtx);
 	pm_runtime_enable(uport->dev);
+	tty_port_set_policy(&uport->state->port, SCHED_FIFO, 1);
 }
 
 static int msm_hs_runtime_suspend(struct device *dev)

--- a/drivers/tty/serial/msm_serial_hs.c
+++ b/drivers/tty/serial/msm_serial_hs.c
@@ -2759,6 +2759,7 @@ static int uartdm_init_port(struct uart_port *uport)
 	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
 	struct msm_hs_tx *tx = &msm_uport->tx;
 	struct msm_hs_rx *rx = &msm_uport->rx;
+	struct sched_param param = { .sched_priority = 1 };
 
 	init_waitqueue_head(&rx->wait);
 	init_waitqueue_head(&tx->wait);
@@ -2773,6 +2774,8 @@ static int uartdm_init_port(struct uart_port *uport)
 		MSM_HS_ERR("%s(): error creating task\n", __func__);
 		goto exit_lh_init;
 	}
+	sched_setscheduler(rx->task, SCHED_FIFO, &param);
+
 	kthread_init_work(&rx->kwork, msm_serial_hs_rx_work);
 
 	kthread_init_worker(&tx->kworker);
@@ -2782,6 +2785,7 @@ static int uartdm_init_port(struct uart_port *uport)
 		MSM_HS_ERR("%s(): error creating task\n", __func__);
 		goto exit_lh_init;
 	}
+	sched_setscheduler(tx->task, SCHED_FIFO, &param);
 
 	kthread_init_work(&tx->kwork, msm_serial_hs_tx_work);
 


### PR DESCRIPTION
msm_serial_hs threads for RX and TX are responsible for passing key
Bluetooth buffers, such as Bluetooth audio, between the Bluetooth HW and
the upper layers of the stack.  These threads are therefore on the
critical path for Bluetooth audio latency, and should be scheduled as
RT threads in order to ensure that they meet audio deadlines.

Cherry picked from:
commit e5ed4788fdcc6 ("Make msm_serial_hs RT to improve Bluetooth performance")

Bug: 36106419
Test: Play Bluetooth audio, confirm msm_serial_hs_0 threads are
      scheduled as RT threads via systrace
Change-Id: Ia2f6fa43926ec8088011de9e49c5961fef08deab
Signed-off-by: Philip Cuadra <philipcuadra@google.com>
Signed-off-by: Petri Gynther <pgynther@google.com>
(cherry picked from commit 47328d52fdcfa6df7c5e45342cb8e333c08d044c)
(cherry picked from commit d630379c0ca3c8f20339f4ef2a6d584dca08c1f4)
(cherry picked from commit 6a20334d0d30b48bd9e77d3cb8e6d83626fcb759)
(cherry picked from commit 9f516a19f48273c55764f2bbb2ce8228c9758086)
(cherry picked from commit 15b525f5ec26ee27ad9e534e67a861bff396b49f)
(cherry picked from commit d19a4b7c6ff425869245b519bfd1f56cdc6cee06)
(cherry picked from commit 9158578585c89806de36b37c09e0d3a28e48b95e)
(cherry picked from commit 6576af7792b5eaf811c2f4a1c63d1ef4e465f112)
(cherry picked from commit c38f00704ea2f13e8e44d6a017ae106bac54e7c7)