### PR TITLE
fs: namespace: Default mount to noatime

### DIFF
--- a/fs/namespace.c
+++ b/fs/namespace.c
@@ -2888,9 +2888,9 @@ long do_mount(const char *dev_name, const char __user *dir_name,
 	if (retval)
 		goto dput_out;
 
-	/* Default to relatime unless overriden */
-	if (!(flags & MS_NOATIME))
-		mnt_flags |= MNT_RELATIME;
+	/* Default to noatime unless overriden */
+	if (!(flags & MS_RELATIME))
+		mnt_flags |= MNT_NOATIME;
 
 	/* Separate the per-mountpoint flags */
 	if (flags & MS_NOSUID)


### PR DESCRIPTION
relatime is used on Linux because of Mutt software.
Nothing on Android depends on atime value to be updated.
