### PR TITLE
ANDROID: ext4: avoid log spams in ext4_umount_end

### DIFF
--- a/fs/ext4/super.c
+++ b/fs/ext4/super.c
@@ -5305,11 +5305,13 @@ static void ext4_umount_end(struct super_block *sb, int flags)
 	 * next boot.
 	 */
 	if ((flags & MNT_FORCE) || atomic_read(&sb->s_active) > 1) {
-		ext4_msg(sb, KERN_ERR,
-			"errors=remount-ro for active namespaces on umount %x",
+		if (test_opt(sb, ERRORS_PANIC)) {
+			ext4_msg(sb, KERN_ERR,
+				"errors=remount-ro for active namespaces on umount %x",
 						flags);
-		clear_opt(sb, ERRORS_PANIC);
-		set_opt(sb, ERRORS_RO);
+			clear_opt(sb, ERRORS_PANIC);
+			set_opt(sb, ERRORS_RO);
+		}
 		/* to write the latest s_kbytes_written */
 		if (!(sb->s_flags & MS_RDONLY))
 			ext4_commit_super(sb, 1);


### PR DESCRIPTION
We don't need to print unnecessary mode change message in ext4 which gives huge
spams when mounting/unmounting apexes.

Bug: 147534629
Change-Id: I6576ffd3d7cde455bf5ddf600b2b86fa8034aec1
Signed-off-by: Jaegeuk Kim <jaegeuk@google.com>
Signed-off-by: atndko <z1281552865@gmail.com>