### PR TITLE
msm: kgsl: Stop slab shrinker when no more pages can be reclaimed

### DIFF
--- a/drivers/gpu/msm/kgsl_pool.c
+++ b/drivers/gpu/msm/kgsl_pool.c
@@ -486,12 +486,16 @@ kgsl_pool_shrink_scan_objects(struct shrinker *shrinker,
 	/* nr represents number of pages to be removed*/
 	int nr = sc->nr_to_scan;
 	int total_pages = kgsl_pool_size_total();
+	unsigned long ret;
 
 	/* Target pages represents new  pool size */
 	int target_pages = (nr > total_pages) ? 0 : (total_pages - nr);
 
 	/* Reduce pool size to target_pages */
-	return kgsl_pool_reduce(target_pages, false);
+	ret = kgsl_pool_reduce(target_pages, false);
+
+	/* If we are unable to shrink more, stop trying */
+	return (ret == 0) ? SHRINK_STOP : ret;
 }
 
 static unsigned long


### PR DESCRIPTION
do_shrink_slab() scans each shrinker in batches of at most
batch_size (128) pages at a time until total_scan pages are
scanned or until shrinker returns SHRINK_STOP. Under heavy
memory pressure total_scan can be large (in thousands) and
kgsl_pool_shrink_scan_objects() ends up returning 0 after
all pages that were reclaimable are reclaimed. This results in
multiple calls to kgsl_pool_shrink_scan_objects() that do not
reclaim any memory. To prevent this kgsl_pool_shrink_scan_objects()
is modified to return SHRINK_STOP as soon as no more memory can
be reclaimed.

Bug: 69931996
Test: tested using alloc-stress with additional traces

Change-Id: Ia48fc2c0d888c54ec9642c0b0962a70ca3cb4c5e
Signed-off-by: Suren Baghdasaryan <surenb@google.com>
Signed-off-by: atndko <z1281552865@gmail.com>