### PR TITLE
block: loop: set non-rotational queue flag

### DIFF
--- a/drivers/block/loop.c
+++ b/drivers/block/loop.c
@@ -1869,6 +1869,8 @@ static int loop_add(struct loop_device **l, int i)
 	 */
 	queue_flag_set_unlocked(QUEUE_FLAG_NOMERGES, lo->lo_queue);
 
+	queue_flag_set_unlocked(QUEUE_FLAG_NONROT, lo->lo_queue);
+
 	err = -ENOMEM;
 	disk = lo->lo_disk = alloc_disk(1 << part_shift);
 	if (!disk)


### PR DESCRIPTION
All of the backing devices we will potentially be using loop on will be
solid state.

Signed-off-by: kdrag0n <dragon@khronodragon.com>