### PR TITLE
msm: kgsl: Increase worker thread priority

### DIFF
--- a/drivers/gpu/msm/kgsl.c
+++ b/drivers/gpu/msm/kgsl.c
@@ -5170,7 +5170,7 @@ static void kgsl_core_exit(void)
 static int __init kgsl_core_init(void)
 {
 	int result = 0;
-	struct sched_param param = { .sched_priority = 2 };
+	struct sched_param param = { .sched_priority = 16 };
 
 	place_marker("M - DRIVER KGSL Init");
 


### PR DESCRIPTION
Currently, the kgsl worker thread is erroneously ranked right below
Android's audio threads in terms of priority.

The kgsl worker thread is in the critical path for rendering frames to
the display, so increase its priority to match the priority of the
display commit threads.

Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>