### PR TITLE
drm/msm/sde: Remove unneeded PM QoS requests

### DIFF
--- a/drivers/gpu/drm/msm/sde/sde_encoder.c
+++ b/drivers/gpu/drm/msm/sde/sde_encoder.c
@@ -237,7 +237,6 @@ enum sde_enc_rc_states {
  * @recovery_events_enabled:	status of hw recovery feature enable by client
  * @elevated_ahb_vote:		increase AHB bus speed for the first frame
  *				after power collapse
- * @pm_qos_cpu_req:		pm_qos request for cpu frequency
  */
 struct sde_encoder_virt {
 	struct drm_encoder base;
@@ -300,43 +299,9 @@ struct sde_encoder_virt {
 
 	bool recovery_events_enabled;
 	bool elevated_ahb_vote;
-	struct pm_qos_request pm_qos_cpu_req;
 };
 
 #define to_sde_encoder_virt(x) container_of(x, struct sde_encoder_virt, base)
-
-static void _sde_encoder_pm_qos_add_request(struct drm_encoder *drm_enc,
-	struct sde_kms *sde_kms)
-{
-	struct sde_encoder_virt *sde_enc = to_sde_encoder_virt(drm_enc);
-	struct pm_qos_request *req;
-	u32 cpu_mask;
-	u32 cpu_dma_latency;
-
-	if (!sde_kms->catalog || !sde_kms->catalog->perf.cpu_mask)
-		return;
-
-	cpu_mask = sde_kms->catalog->perf.cpu_mask;
-	cpu_dma_latency = sde_kms->catalog->perf.cpu_dma_latency;
-
-	req = &sde_enc->pm_qos_cpu_req;
-	req->type = PM_QOS_REQ_AFFINE_CORES;
-	atomic_set(&req->cpus_affine, cpu_mask);
-	pm_qos_add_request(req, PM_QOS_CPU_DMA_LATENCY, cpu_dma_latency);
-
-	SDE_EVT32_VERBOSE(DRMID(drm_enc), cpu_mask, cpu_dma_latency);
-}
-
-static void _sde_encoder_pm_qos_remove_request(struct drm_encoder *drm_enc,
-	struct sde_kms *sde_kms)
-{
-	struct sde_encoder_virt *sde_enc = to_sde_encoder_virt(drm_enc);
-
-	if (!sde_kms->catalog || !sde_kms->catalog->perf.cpu_mask)
-		return;
-
-	pm_qos_remove_request(&sde_enc->pm_qos_cpu_req);
-}
 
 static struct drm_connector_state *_sde_encoder_get_conn_state(
 		struct drm_encoder *drm_enc)
@@ -2282,13 +2247,7 @@ static int _sde_encoder_resource_control_helper(struct drm_encoder *drm_enc,
 		/* enable all the irq */
 		_sde_encoder_irq_control(drm_enc, true);
 
-		if (is_cmd_mode)
-			_sde_encoder_pm_qos_add_request(drm_enc, sde_kms);
-
 	} else {
-		if (is_cmd_mode)
-			_sde_encoder_pm_qos_remove_request(drm_enc, sde_kms);
-
 		/* disable all the irq */
 		_sde_encoder_irq_control(drm_enc, false);
 

--- a/drivers/media/platform/msm/sde/rotator/sde_rotator_base.c
+++ b/drivers/media/platform/msm/sde/rotator/sde_rotator_base.c
@@ -802,14 +802,6 @@ static int sde_mdp_parse_dt_misc(struct platform_device *pdev,
 
 	sde_mdp_parse_inline_rot_lut_setting(pdev, mdata);
 
-	rc = of_property_read_u32(pdev->dev.of_node,
-		"qcom,mdss-rot-qos-cpu-mask", &data);
-	mdata->rot_pm_qos_cpu_mask = (!rc ? data : 0);
-
-	rc = of_property_read_u32(pdev->dev.of_node,
-		 "qcom,mdss-rot-qos-cpu-dma-latency", &data);
-	mdata->rot_pm_qos_cpu_dma_latency = (!rc ? data : 0);
-
 	mdata->mdp_base = mdata->sde_io.base + SDE_MDP_OFFSET;
 
 	return 0;

--- a/drivers/media/platform/msm/sde/rotator/sde_rotator_base.h
+++ b/drivers/media/platform/msm/sde/rotator/sde_rotator_base.h
@@ -25,7 +25,6 @@
 #include "sde_rotator_io_util.h"
 #include "sde_rotator_smmu.h"
 #include "sde_rotator_formats.h"
-#include <linux/pm_qos.h>
 
 /* HW Revisions for different targets */
 #define SDE_GET_MAJOR_REV(rev)	((rev) >> 28)
@@ -269,11 +268,6 @@ struct sde_rot_data_type {
 	u32 npriority_lvl;
 
 	u32 vbif_xin_id[MAX_XIN];
-
-	struct pm_qos_request pm_qos_rot_cpu_req;
-	u32 rot_pm_qos_cpu_count;
-	u32 rot_pm_qos_cpu_mask;
-	u32 rot_pm_qos_cpu_dma_latency;
 
 	u32 vbif_memtype_count;
 	u32 *vbif_memtype;

--- a/drivers/media/platform/msm/sde/rotator/sde_rotator_core.c
+++ b/drivers/media/platform/msm/sde/rotator/sde_rotator_core.c
@@ -3208,8 +3208,6 @@ int sde_rotator_core_init(struct sde_rot_mgr **pmgr,
 		goto error_hw_init;
 	}
 
-	sde_rotator_pm_qos_add(mdata);
-
 	ret = sde_rotator_init_queue(mgr);
 	if (ret) {
 		SDEROT_ERR("fail to init queue\n");

--- a/drivers/media/platform/msm/sde/rotator/sde_rotator_dev.c
+++ b/drivers/media/platform/msm/sde/rotator/sde_rotator_dev.c
@@ -55,15 +55,8 @@
 #define SDE_ROTATOR_DEGREE_180		180
 #define SDE_ROTATOR_DEGREE_90		90
 
-/* Inline rotator qos request */
-#define SDE_ROTATOR_ADD_REQUEST		1
-#define SDE_ROTATOR_REMOVE_REQUEST		0
-
-
 static void sde_rotator_submit_handler(struct kthread_work *work);
 static void sde_rotator_retire_handler(struct kthread_work *work);
-static void sde_rotator_pm_qos_request(struct sde_rotator_device *rot_dev,
-					 bool add_request);
 #ifdef CONFIG_COMPAT
 static long sde_rotator_compat_ioctl32(struct file *file,
 	unsigned int cmd, unsigned long arg);
@@ -1044,8 +1037,6 @@ struct sde_rotator_ctx *sde_rotator_ctx_open(
 		SDEDEV_DBG(ctx->rot_dev->dev, "timeline is not available\n");
 
 	sde_rot_mgr_lock(rot_dev->mgr);
-	sde_rotator_pm_qos_request(rot_dev,
-				 SDE_ROTATOR_ADD_REQUEST);
 	ret = sde_rotator_session_open(rot_dev->mgr, &ctx->private,
 			ctx->session_id, &ctx->work_queue);
 	if (ret < 0) {
@@ -1170,8 +1161,6 @@ static int sde_rotator_ctx_release(struct sde_rotator_ctx *ctx,
 	}
 	SDEDEV_DBG(rot_dev->dev, "release session s:%d\n", session_id);
 	sde_rot_mgr_lock(rot_dev->mgr);
-	sde_rotator_pm_qos_request(rot_dev,
-			SDE_ROTATOR_REMOVE_REQUEST);
 	sde_rotator_session_close(rot_dev->mgr, ctx->private, session_id);
 	sde_rot_mgr_unlock(rot_dev->mgr);
 	SDEDEV_DBG(rot_dev->dev, "release retire work s:%d\n", session_id);
@@ -1284,99 +1273,6 @@ static bool sde_rotator_is_request_retired(struct sde_rotator_request *request)
 	SDEROT_DBG("sequence:%u/%u\n", sequence_id, ctx->retired_sequence_id);
 
 	return retire_delta >= 0;
-}
-
-static void sde_rotator_pm_qos_remove(struct sde_rot_data_type *rot_mdata)
-{
-	struct pm_qos_request *req;
-	u32 cpu_mask;
-
-	if (!rot_mdata) {
-		SDEROT_DBG("invalid rot device or context\n");
-		return;
-	}
-
-	cpu_mask = rot_mdata->rot_pm_qos_cpu_mask;
-
-	if (!cpu_mask)
-		return;
-
-	req = &rot_mdata->pm_qos_rot_cpu_req;
-	pm_qos_remove_request(req);
-}
-
-void sde_rotator_pm_qos_add(struct sde_rot_data_type *rot_mdata)
-{
-	struct pm_qos_request *req;
-	u32 cpu_mask;
-
-	if (!rot_mdata) {
-		SDEROT_DBG("invalid rot device or context\n");
-		return;
-	}
-
-	cpu_mask = rot_mdata->rot_pm_qos_cpu_mask;
-
-	if (!cpu_mask)
-		return;
-
-	req = &rot_mdata->pm_qos_rot_cpu_req;
-	req->type = PM_QOS_REQ_AFFINE_CORES;
-	atomic_set(&req->cpus_affine, cpu_mask);
-	pm_qos_add_request(req, PM_QOS_CPU_DMA_LATENCY,
-		PM_QOS_DEFAULT_VALUE);
-
-	SDEROT_DBG("rotator pmqos add mask %x latency %x\n",
-		rot_mdata->rot_pm_qos_cpu_mask,
-		rot_mdata->rot_pm_qos_cpu_dma_latency);
-}
-
-static void sde_rotator_pm_qos_request(struct sde_rotator_device *rot_dev,
-					 bool add_request)
-{
-	u32 cpu_mask;
-	u32 cpu_dma_latency;
-	bool changed = false;
-
-	if (!rot_dev) {
-		SDEROT_DBG("invalid rot device or context\n");
-		return;
-	}
-
-	cpu_mask = rot_dev->mdata->rot_pm_qos_cpu_mask;
-	cpu_dma_latency = rot_dev->mdata->rot_pm_qos_cpu_dma_latency;
-
-	if (!cpu_mask)
-		return;
-
-	if (add_request) {
-		if (rot_dev->mdata->rot_pm_qos_cpu_count == 0)
-			changed = true;
-		rot_dev->mdata->rot_pm_qos_cpu_count++;
-	} else {
-		if (rot_dev->mdata->rot_pm_qos_cpu_count != 0) {
-			rot_dev->mdata->rot_pm_qos_cpu_count--;
-			if (rot_dev->mdata->rot_pm_qos_cpu_count == 0)
-				changed = true;
-		} else {
-			SDEROT_DBG("%s: ref_count is not balanced\n",
-				__func__);
-		}
-	}
-
-	if (!changed)
-		return;
-
-	SDEROT_EVTLOG(add_request, cpu_mask, cpu_dma_latency);
-
-	if (!add_request) {
-		pm_qos_update_request(&rot_dev->mdata->pm_qos_rot_cpu_req,
-			PM_QOS_DEFAULT_VALUE);
-		return;
-	}
-
-	pm_qos_update_request(&rot_dev->mdata->pm_qos_rot_cpu_req,
-		cpu_dma_latency);
 }
 
 /*
@@ -3718,7 +3614,6 @@ static int sde_rotator_remove(struct platform_device *pdev)
 		return 0;
 	}
 
-	sde_rotator_pm_qos_remove(rot_dev->mdata);
 	for (i = MAX_ROT_OPEN_SESSION - 1; i >= 0; i--)
 		kthread_stop(rot_dev->rot_thread[i]);
 	sde_rotator_destroy_debugfs(rot_dev->debugfs_root);

--- a/drivers/media/platform/msm/sde/rotator/sde_rotator_dev.h
+++ b/drivers/media/platform/msm/sde/rotator/sde_rotator_dev.h
@@ -260,6 +260,4 @@ struct sde_rot_mgr *sde_rot_mgr_from_device(struct device *dev)
 	return ((struct sde_rotator_device *) dev_get_drvdata(dev))->mgr;
 }
 
-void sde_rotator_pm_qos_add(struct sde_rot_data_type *rot_mdata);
-
 #endif /* __SDE_ROTATOR_DEV_H__ */


### PR DESCRIPTION
These are blocking some CPUs in the LITTLE cluster from entering deep
idle because the driver assumes that display rendering work occurs on a
hardcoded set of CPUs, which is false. The scope of this is also quite
large, which increases power consumption.

Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>