### PR TITLE
PM: sleep: Don't allow s2idle to be used

### DIFF
--- a/kernel/power/main.c
+++ b/kernel/power/main.c
@@ -127,6 +127,8 @@ static ssize_t mem_sleep_store(struct kobject *kobj, struct kobj_attribute *attr
 	suspend_state_t state;
 	int error;
 
+	/* Don't allow userspace to select s2idle */
+	return n;
 	error = pm_autosleep_lock();
 	if (error)
 		return error;


### PR DESCRIPTION
Unfortunately, s2idle is only somewhat functional. Although commit
70441d36af58 ("cpuidle: lpm_levels: add soft watchdog for s2idle") makes
s2idle usable, there are still CPU stalls caused by s2idle's buggy
behavior, and the aforementioned hack doesn't address them. Therefore,
let's stop userspace from enabling s2idle and instead enforce the
default deep sleep mode.

Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>