### PR TITLE
ASoC: codecs: Fix uninitialized variable usage

### DIFF
--- a/techpack/audio/asoc/codecs/wcd_cpe_core.c
+++ b/techpack/audio/asoc/codecs/wcd_cpe_core.c
@@ -2907,7 +2907,7 @@ static int wcd_cpe_send_param_snd_model(struct wcd_cpe_core *core,
 	struct cmi_obm_msg obm_msg;
 	struct cpe_param_data *param_d;
 
-
+	memset(&obm_msg, 0, sizeof(obm_msg));
 	ret = fill_cmi_header(&obm_msg.hdr, session->id,
 			CMI_CPE_LSM_SERVICE_ID, 0, 20,
 			CPE_LSM_SESSION_CMD_SET_PARAMS_V2, true);
@@ -3608,6 +3608,7 @@ static int wcd_cpe_lsm_eob(
 	int ret = 0;
 	struct cmi_hdr lab_eob;
 
+	memset(&lab_eob, 0, sizeof(lab_eob));
 	if (fill_lsm_cmd_header_v0_inband(&lab_eob, session->id,
 		0, CPE_LSM_SESSION_CMD_EOB)) {
 		return -EINVAL;
@@ -4163,6 +4164,7 @@ static int wcd_cpe_send_afe_cal(void *core_handle,
 		struct cmi_hdr *hdr = &(obm_msg.hdr);
 		struct cmi_obm *pld = &(obm_msg.pld);
 
+		memset(&obm_msg, 0, sizeof(obm_msg));
 		rc = wcd_cpe_afe_shmem_alloc(core, port_d,
 					afe_cal->cal_data.size);
 		if (rc) {

--- a/techpack/audio/dsp/q6afe.c
+++ b/techpack/audio/dsp/q6afe.c
@@ -7445,6 +7445,7 @@ static int afe_get_sp_th_vi_v_vali_data(
 
 	mutex_lock(&this_afe.afe_cmd_lock);
 	memset(&param_hdr, 0, sizeof(param_hdr));
+	memset(th_vi_v_vali, 0, sizeof(*th_vi_v_vali));
 
 	param_hdr.module_id = AFE_MODULE_SPEAKER_PROTECTION_V2_TH_VI;
 	param_hdr.instance_id = INSTANCE_ID_0;

--- a/techpack/audio/dsp/voice_mhi.c
+++ b/techpack/audio/dsp/voice_mhi.c
@@ -437,7 +437,7 @@ static int voice_mhi_pcie_up_callback(struct mhi_device *voice_mhi_dev,
 static void voice_mhi_pcie_down_callback(struct mhi_device *voice_mhi_dev)
 {
 	dma_addr_t iova;
-	struct device *md;
+	struct device *md = NULL;
 
 	mutex_lock(&voice_mhi_lcl.mutex);
 


### PR DESCRIPTION
Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>