### PR TITLE
qcacld-3.0: Fix uninitialized sessionId usage on error

### DIFF
--- a/drivers/staging/qcacld-3.0/core/hdd/src/wlan_hdd_tsf.c
+++ b/drivers/staging/qcacld-3.0/core/hdd/src/wlan_hdd_tsf.c
@@ -2247,7 +2247,10 @@ static int __wlan_hdd_cfg80211_handle_tsf_cmd(struct wiphy *wiphy,
 	tsf_cmd = nla_get_u32(tb_vendor[QCA_WLAN_VENDOR_ATTR_TSF_CMD]);
 
 	if (tsf_cmd == QCA_TSF_CAPTURE || tsf_cmd == QCA_TSF_SYNC_GET) {
-		hdd_capture_tsf(adapter, tsf_op_resp, 1);
+		status = hdd_capture_tsf(adapter, tsf_op_resp, 1);
+		if (status != QDF_STATUS_SUCCESS)
+			goto end;
+
 		switch (tsf_op_resp[0]) {
 		case TSF_RETURN:
 			status = 0;

--- a/drivers/staging/qcacld-3.0/core/sme/src/csr/csr_api_roam.c
+++ b/drivers/staging/qcacld-3.0/core/sme/src/csr/csr_api_roam.c
@@ -11083,6 +11083,9 @@ void csr_roam_joined_state_msg_processor(struct mac_context *mac, void *msg_buf)
 							(struct qdf_mac_addr *)
 							   pUpperLayerAssocCnf->
 							   bssId, &sessionId);
+		if (!QDF_IS_STATUS_SUCCESS(status))
+			return;
+
 		pSession = CSR_GET_SESSION(mac, sessionId);
 
 		if (!pSession) {


### PR DESCRIPTION
The return value from csr_roam_get_session_id_from_bssid() isn't
checked, and when it returns an error, it won't initialize sessionId.
Fix it by checking the return value, and exiting when there's an error.

Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>