### PR TITLE
drm: Fix uninitialized variable usage in drm_plane_helper_check_update()

### DIFF
--- a/drivers/gpu/drm/drm_plane_helper.c
+++ b/drivers/gpu/drm/drm_plane_helper.c
@@ -243,7 +243,6 @@ int drm_plane_helper_check_update(struct drm_plane *plane,
 		.crtc_w = drm_rect_width(dst),
 		.crtc_h = drm_rect_height(dst),
 		.rotation = rotation,
-		.visible = *visible,
 	};
 	int ret;
 


### PR DESCRIPTION
'visible' is an output field; using it for input makes no sense, and
rightfully results in uninitialized variable usage. Fix it by removing
its incorrect usage as an input.

Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>