### PR TITLE
irqchip: qcom: pdc: Don't overwrite IRQ domain name on init

### DIFF
--- a/drivers/irqchip/qcom/pdc.c
+++ b/drivers/irqchip/qcom/pdc.c
@@ -376,8 +376,6 @@ int qcom_pdc_init(struct device_node *node,
 	if (pin_count % IRQS_PER_REG)
 		max_enable_regs++;
 
-	pdc_domain->name = "qcom,pdc";
-
 	return 0;
 
 failure:


### PR DESCRIPTION
The IRQ subsystem allocates a domain name dynamically on its own. By
overwriting it, there is not only a memory leak created, but also a
kfree() on a non-allocated pointer when the IRQ is freed. We can remedy
all of this by simply not overwriting the IRQ domain name.

Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>