### PR TITLE
kernel: cpuset: Allow disabling CONFIG_CPUSET_ASSIST

### DIFF
--- a/kernel/cgroup/cpuset.c
+++ b/kernel/cgroup/cpuset.c
@@ -1775,6 +1775,7 @@ out_unlock:
 	return retval ?: nbytes;
 }
 
+#ifdef CONFIG_CPUSET_ASSIST
 static ssize_t cpuset_write_resmask_assist(struct kernfs_open_file *of,
 					   struct cs_target tgt, size_t nbytes,
 					   loff_t off)
@@ -1786,7 +1787,6 @@ static ssize_t cpuset_write_resmask_assist(struct kernfs_open_file *of,
 static ssize_t cpuset_write_resmask_wrapper(struct kernfs_open_file *of,
 					 char *buf, size_t nbytes, loff_t off)
 {
-#ifdef CONFIG_CPUSET_ASSIST
 	static struct cs_target cs_targets[] = {
 		{ "audio-app",		CONFIG_CPUSET_AUDIO_APP },
 		{ "background",		CONFIG_CPUSET_BG },
@@ -1809,12 +1809,12 @@ static ssize_t cpuset_write_resmask_wrapper(struct kernfs_open_file *of,
 								   nbytes, off);
 		}
 	}
-#endif
 
 	buf = strstrip(buf);
 
 	return cpuset_write_resmask(of, buf, nbytes, off);
 }
+#endif
 
 /*
  * These ascii lists should be read in a single call, by using a user
@@ -1908,7 +1908,11 @@ static struct cftype files[] = {
 	{
 		.name = "cpus",
 		.seq_show = cpuset_common_seq_show,
+#ifdef CONFIG_CPUSET_ASSIST
 		.write = cpuset_write_resmask_wrapper,
+#else
+		.write = cpuset_write_resmask,
+#endif
 		.max_write_len = (100U + 6 * NR_CPUS),
 		.private = FILE_CPULIST,
 	},


### PR DESCRIPTION
Was needed for bootanimation fix search.