### PR TITLE
kernel: sched: Allow disabling CONFIG_STUNE_ASSIST

### DIFF
--- a/kernel/sched/tune.c
+++ b/kernel/sched/tune.c
@@ -652,24 +652,40 @@ static struct cftype files[] = {
 	{
 		.name = "sched_boost_no_override",
 		.read_u64 = sched_boost_override_read,
+#ifdef CONFIG_STUNE_ASSIST
+		.write_u64 = sched_boost_override_write_wrapper,
+#else
 		.write_u64 = sched_boost_override_write,
+#endif
 	},
 #ifdef CONFIG_SCHED_WALT
 	{
 		.name = "colocate",
 		.read_u64 = sched_colocate_read,
+#ifdef CONFIG_STUNE_ASSIST
+		.write_u64 = sched_colocate_write_wrapper,
+#else
 		.write_u64 = sched_colocate_write,
+#endif
 	},
 #endif
 	{
 		.name = "boost",
 		.read_s64 = boost_read,
+#ifdef CONFIG_STUNE_ASSIST
 		.write_s64 = boost_write_wrapper,
+#else
+		.write_s64 = boost_write,
+#endif
 	},
 	{
 		.name = "prefer_idle",
 		.read_u64 = prefer_idle_read,
+#ifdef CONFIG_STUNE_ASSIST
 		.write_u64 = prefer_idle_write_wrapper,
+#else
+		.write_u64 = prefer_idle_write,
+#endif
 	},
 	{ }	/* terminate */
 };


### PR DESCRIPTION
Was needed for bootanimation fix search.