### PR TITLE
cpufreq: Force the LITTLE cluster to only use the default governor

### DIFF
--- a/drivers/cpufreq/cpufreq.c
+++ b/drivers/cpufreq/cpufreq.c
@@ -789,6 +789,13 @@ static ssize_t store_scaling_governor(struct cpufreq_policy *policy,
 	char	str_governor[16];
 	struct cpufreq_policy new_policy;
 
+	/*
+	 * Force the LITTLE CPU cluster to use the default govenor (performance)
+	 * because keeping it at its maximum frequency is best.
+	 */
+	if (cpumask_test_cpu(policy->cpu, cpu_lp_mask))
+		return count;
+
 	memcpy(&new_policy, policy, sizeof(*policy));
 
 	ret = sscanf(buf, "%15s", str_governor);


### PR DESCRIPTION
Since the LITTLE cluster now only has two frequencies, both of which are
very close to one another, it doesn't make much sense to keep schedutil
running for it when there's almost no power difference between the two
frequencies. As such, force the LITTLE cluster to stick to the default
CPU governor, which is always sanely set to performance.

Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>